### PR TITLE
Fixed integration with Repetier-Host 1.0.3

### DIFF
--- a/CncPlugin/CncControl.cs
+++ b/CncPlugin/CncControl.cs
@@ -162,7 +162,11 @@ namespace CncPlugin
         // Return the UserControl.
         public Control ComponentControl { get { return this; } }
 
-        #endregion
+		// Handle the new interface functions in repetier host 1.0.3
+		public Control ComponentControl { get { return this; } }
+	    public ThreeDView Associated3DView { get { return null; } }
+        
+		#endregion
 
         #region Button functions
 


### PR DESCRIPTION
Repetier host wont load the addon without these 2 extra interface
functions. CNCplugin now loads and operates normaly.
